### PR TITLE
Update repository to make the URL clickable in terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Expose environment variables to the runtime config of Next.js",
   "main": "index.js",
   "license": "MIT",
-  "repository": "git@github.com:tusbar/next-runtime-dotenv.git",
+  "repository": "https://github.com/tusbar/next-runtime-dotenv",
   "author": "Bertrand Marron <bertrand.marron@gmail.com>",
   "scripts": {
     "test": "jest"


### PR DESCRIPTION
Hello!
A git definition is not clickable in the term ;)

<img width="826" alt="Capture d’écran 2020-11-22 à 21 11 51" src="https://user-images.githubusercontent.com/1231232/99915951-5a6c4c80-2d07-11eb-93c5-dea87c67c097.png">
